### PR TITLE
Fix broken rasterization paper link

### DIFF
--- a/src/data/resources/high_perf_sw_rasterization_gpu.toml
+++ b/src/data/resources/high_perf_sw_rasterization_gpu.toml
@@ -1,5 +1,5 @@
 title = "High-Performance Software Rasterization on GPUs (2011)"
 categories = ["Rasterization/Software Rasterization", "GPU Compute/Applications"]
-link = "https://users.aalto.fi/~laines9/publications/laine2011hpg_paper.pdf"
+link = "https://research.nvidia.com/sites/default/files/pubs/2011-08_High-Performance-Software-Rasterization/laine2011hpg_paper.pdf"
 description = "A paper describing high-performance software rasterization techniques running on GPUs."
 formats = ["paper"]


### PR DESCRIPTION
## Summary

Fixes the broken PDF link for the “High-Performance Software Rasterization on GPUs (2011)” resource. The old Aalto URL now returns 404, and NVIDIA Research hosts the same paper PDF at the replacement URL.

Closes #15

## Validation

- `curl.exe -L -s -o NUL -w '%{http_code} %{content_type}' --max-time 20 'https://users.aalto.fi/~laines9/publications/laine2011hpg_paper.pdf'` returns `404 text/html`
- `curl.exe -L -s -o NUL -w '%{http_code} %{content_type} %{url_effective}' --max-time 30 'https://research.nvidia.com/sites/default/files/pubs/2011-08_High-Performance-Software-Rasterization/laine2011hpg_paper.pdf'` returns `200 application/pdf`
- `git diff --check` passed except Windows CRLF warnings

I attempted the documented `pnpm` build path via Corepack, but pnpm refused to run because build scripts for `esbuild` and `sharp` need approval in this environment.